### PR TITLE
Fixing signed integer overflow

### DIFF
--- a/src/g72x.c
+++ b/src/g72x.c
@@ -141,7 +141,7 @@ g72x_init (SF_PRIVATE * psf)
 		else
 			pg72x->blocks_total = psf->datalength / pg72x->blocksize ;
 
-		psf->sf.frames = pg72x->blocks_total * pg72x->samplesperblock ;
+		psf->sf.frames = (sf_count_t) pg72x->blocks_total * pg72x->samplesperblock ;
 
 		psf_g72x_decode_block (psf, pg72x) ;
 		}


### PR DESCRIPTION
Fixing signed integer overflow as reported in https://github.com/libsndfile/libsndfile/issues/757 . A similar fix was applied before https://github.com/libsndfile/libsndfile/pull/818